### PR TITLE
chore: point workflows and package URLs to nordicsemi org

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NordicSemiconductor/nrfprogrammer-firmware-images.git"
+    "url": "git+https://github.com/nordicsemi/nrfprogrammer-firmware-images.git"
   },
   "author": "Nordic Semiconductor ASA | nordicsemi.no",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/NordicSemiconductor/nrfprogrammer-firmware-images/issues"
+    "url": "https://github.com/nordicsemi/nrfprogrammer-firmware-images/issues"
   },
-  "homepage": "https://github.com/NordicSemiconductor/nrfprogrammer-firmware-images#readme",
+  "homepage": "https://github.com/nordicsemi/nrfprogrammer-firmware-images#readme",
   "devDependencies": {
     "@bifravst/eslint-config-typescript": "6.4.4",
     "@bifravst/prettier-config": "1.1.17",


### PR DESCRIPTION
Update reusable workflow references and repository homepage/URL from NordicSemiconductor to nordicsemi.

## Summary

Updates all reusable workflow `uses:` paths from `NordicSemiconductor/pc-nrfconnect-shared` to `nordicsemi/pc-nrfconnect-shared` to match the enterprise organization naming.

`package.json` `homepage` and `repository.url` point at the canonical **nordicsemi** org (not the former NordicSemiconductor naming).

## Notes

No functional workflow logic changes; only the repository path in composite/reusable workflow references, plus `package.json` metadata for the official GitHub location.